### PR TITLE
gracefully fail when the semaphore can't be created

### DIFF
--- a/readsbrrd.c
+++ b/readsbrrd.c
@@ -571,7 +571,7 @@ int main(int argc, char** argv) {
     }
 
     stats_semptr = sem_open("/readsbStatsTrigger", O_CREAT, 0644, 0);
-    if (stats_semptr == (void*) - 1) {
+    if (stats_semptr == SEM_FAILED) {
         fprintf(stderr, "error creating stats semaphore: %s\n", strerror(errno));
         cleanup_and_exit(4);
     }


### PR DESCRIPTION
sem_open failure detection didn't work for me comparing against -1
According to man page:
On error, sem_open() returns SEM_FAILED, with errno set to indicate the error.
Detecting failure like that works for me.