### PR TITLE
Replaces deprecated  sys_siglist[sig] with strsignal(sig) in readsbrr…

### DIFF
--- a/readsbrrd.c
+++ b/readsbrrd.c
@@ -20,7 +20,6 @@
 #include "readsbrrd.h"
 #include "readsb.pb-c.h"
 
-extern const char * const sys_siglist[];
 static int readsbrrd_exit = 0;
 static uint8_t *read_buf;
 static error_t parse_opt(int key, char *arg, struct argp_state *state);
@@ -100,7 +99,7 @@ static rrd_struct rrd;
 static void signal_handler(int sig) {
     signal(sig, SIG_DFL); // Reset signal handler
     readsbrrd_exit = 1;
-    fprintf(stderr, "caught signal %s, shutting down..\n", sys_siglist[sig]);
+    fprintf(stderr, "caught signal %s, shutting down..\n", strsignal(sig));
 }
 
 /**


### PR DESCRIPTION
Running make on the latest ArchLinuxARM-rpi-4 throws the following error:

/usr/bin/ld: readsbrrd.o: in function `signal_handler':
/home/glillig/github/Mictronics/readsb-protobuf/readsbrrd.c:103: undefined reference to `sys_siglist'
collect2: error: ld returned 1 exit status
make: *** [Makefile:81: readsbrrd] Error 1

This happens due to the glibc version 2.32-2 installed. Searching the net showed that since version 2.32
the deprecated arrays sys_siglist, _sys_siglist, and sys_sigabbrev are no longer available to newly linked 
binaries, and their declarations have been removed from <string.h>.

This fix replaces sys_siglist[sig] with strsignal(sig) in readsbrrd.c.