### PR TITLE
Removed incorrect "../" from the head of the graphs URL

### DIFF
--- a/webapp/src/index.html
+++ b/webapp/src/index.html
@@ -698,7 +698,7 @@
                     ></div>
                     <div class="col-sm text-end">
                       <a
-                        href="../graphs/"
+                        href="graphs/"
                         target="_blank"
                         data-i18n="info.graphsLink"
                         >Performance Graphs</a


### PR DESCRIPTION
Removed "../" from the head of the graphs URL. I believe this was in error, and doesn't normally show up since the browser ignores it when index.html is at the root of the domain. However, if the web UI is running behind a reverse proxy that adds a level (or more) to the URL, it was broken before.

I know this is a tiny, tiny push request. If you want to make the change elsewhere, that's fine.