### PR TITLE
fix dropped counter for rtlsdr

### DIFF
--- a/fifo.h
+++ b/fifo.h
@@ -67,7 +67,7 @@ struct mag_buf {
     mag_buf_flags flags; // bitwise flags for this buffer
     double mean_level; // Mean of normalized (0..1) signal level
     double mean_power; // Mean of normalized (0..1) power level
-    unsigned dropped; // (approx) number of dropped samples, if flag MAGBUF_DISCONTINUOUS is set
+    unsigned dropped; // (approx) number of dropped samples
 
     struct mag_buf *next; // linked list forward link
 };

--- a/sdr_plutosdr.c
+++ b/sdr_plutosdr.c
@@ -178,14 +178,16 @@ static void plutosdrCallback(int16_t *buf, uint32_t len) {
     }
 
     outbuf->flags = 0;
+    outbuf->dropped = 0;
 
     if (dropped) {
         // We previously dropped some samples due to no buffers being available
         outbuf->flags |= MAGBUF_DISCONTINUOUS;
         outbuf->dropped = dropped;
-    }
 
-    dropped = 0;
+        // reset dropped counter
+        dropped = 0;
+    }
 
     outbuf->sampleTimestamp = sampleCounter * 12e6 / Modes.sample_rate;
     sampleCounter += samples_read;

--- a/sdr_rtlsdr.c
+++ b/sdr_rtlsdr.c
@@ -285,11 +285,15 @@ static void rtlsdrCallback(unsigned char *buf, uint32_t len, void *ctx) {
     }
 
     outbuf->flags = 0;
+    outbuf->dropped = 0;
 
     if (dropped) {
         // We previously dropped some samples due to no buffers being available
         outbuf->flags |= MAGBUF_DISCONTINUOUS;
         outbuf->dropped = dropped;
+
+        // reset dropped counter
+        dropped = 0;
     }
 
     // Compute the sample timestamp and system timestamp for the start of the block


### PR DESCRIPTION
dropped counter static variable wasn't being reset
outbuf->dropped wasn't being reset but unconditionally used
always reset, remove not about DISCONTINOUS flag in fifo.h