### PR TITLE
Fix compilation against musl libc

### DIFF
--- a/compat/compat.h
+++ b/compat/compat.h
@@ -20,7 +20,7 @@
 
 #else // other platforms
 
-# include <endian.h>
+# include <byteswap.h>
 
 #endif
 

--- a/readsbrrd.c
+++ b/readsbrrd.c
@@ -578,7 +578,7 @@ int main(int argc, char** argv) {
     // Run this until we get a termination signal.
     while (!readsbrrd_exit) {
         clock_gettime(CLOCK_REALTIME, &ts);
-        ts.tv_sec += (__time_t) (rrd.step * 1.5);
+        ts.tv_sec += (__time_t) rrd.step * 1.5;
         r = sem_getvalue(stats_semptr, &semcnt);
         // Avoid frequent updates when more than one event is queued in semaphore.
         // Update only one very last event.

--- a/readsbrrd.c
+++ b/readsbrrd.c
@@ -578,7 +578,7 @@ int main(int argc, char** argv) {
     // Run this until we get a termination signal.
     while (!readsbrrd_exit) {
         clock_gettime(CLOCK_REALTIME, &ts);
-        ts.tv_sec += (__time_t) rrd.step * 1.5;
+        ts.tv_sec += (time_t) rrd.step * 1.5;
         r = sem_getvalue(stats_semptr, &semcnt);
         // Avoid frequent updates when more than one event is queued in semaphore.
         // Update only one very last event.


### PR DESCRIPTION
* readsbrrd: cast timespec.tv_sec addend to time_t
* readsbrrd: fix misplaced widening cast
* compat: include byteswap.h instead of endian.h

The second commit is not a musl fix, but the third commit changes the same code. As it are two changes fixing completely different problems, the changes do not belong in a single commit.