### PR TITLE
readsbrrd: fix compilation with GCC 14

### DIFF
--- a/readsbrrd.c
+++ b/readsbrrd.c
@@ -216,7 +216,7 @@ static int rrd_create_files() {
             snprintf(rrd.argv[6 + r], 256, "%s", rra[r]);
             rrd.argc += 1;
         }
-        rrd.status = rrd_create(rrd.argc, rrd.argv);
+        rrd.status = rrd_create(rrd.argc, (const char **) rrd.argv);
         if (rrd_test_error()) {
             fprintf(stderr, "%s\n", rrd_get_error());
             rrd_clear_error();
@@ -246,7 +246,7 @@ static void rrd_update_file(rrd_file_type_t type, float value) {
         return;
     }
     
-    rrd.status = rrd_update(rrd.argc, rrd.argv);
+    rrd.status = rrd_update(rrd.argc, (const char **) rrd.argv);
     if (rrd_test_error()) {
         fprintf(stderr, "%s\n", rrd_get_error());
         rrd_clear_error();


### PR DESCRIPTION
Due to stricter defaults in GCC 14, readsb compile fails with the following errors in readsbrrd.c:
```
readsbrrd.c: In function ‘rrd_create_files’:
readsbrrd.c:219:46: error: passing argument 2 of ‘rrd_create’ from incompatible pointer type [-Werror=incompatible-pointer-types]
  219 |         rrd.status = rrd_create(rrd.argc, rrd.argv);
      |                                           ~~~^~~~~
      |                                              |
      |                                              char **
In file included from readsbrrd.h:29,
                 from readsbrrd.c:20:
/usr/include/rrd.h:158:5: note: expected ‘const char **’ but argument is of type ‘char **’
  158 |     const char **);
      |     ^~~~~~~~~~~~~
readsbrrd.c: In function ‘rrd_update_file’:
readsbrrd.c:249:42: error: passing argument 2 of ‘rrd_update’ from incompatible pointer type [-Werror=incompatible-pointer-types]
  249 |     rrd.status = rrd_update(rrd.argc, rrd.argv);
      |                                       ~~~^~~~~
      |                                          |
      |                                          char **
/usr/include/rrd.h:179:5: note: expected ‘const char **’ but argument is of type ‘char **’
  179 |     const char **);
      |     ^~~~~~~~~~~~~
```