### PR TITLE
Makefile: add tinfo to LIBS if detected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ CFLAGS += $(DIALECT) -O2 -g -W -D_DEFAULT_SOURCE -Wall -Werror -fno-common -Wmis
 LIBS = -pthread -lpthread -lm -lrt -lncurses -lprotobuf-c -lrrd
 LDFLAGS = 
 
+LIBS += $(shell pkg-config --libs tinfo)
+
 ifeq ($(AGGRESSIVE), yes)
   CPPFLAGS += -DALLOW_AGGRESSIVE
 endif


### PR DESCRIPTION
On systems where ncurses is split in ncurses and tinfo, the following compile error occurs:
```
cc -g -o viewadsb readsb.pb-c.o geomag.o viewadsb.o anet.o interactive.o mode_ac.o mode_s.o comm_b.o net_io.o crc.o stats.o cpr.o icao_filter.o track.o util.o ais_charset.o  -pthread -lpthread -lm -lrt -lncurses -lprotobuf-c -lrrd /usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: interactive.o: undefined reference to symbol 'stdscr' /usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /usr/lib64/libtinfo.so.6: error adding symbols: DSO missing from command line /usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: interactive.o: undefined reference to symbol 'stdscr' /usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /usr/lib64/libtinfo.so.6: error adding symbols: DSO missing from command line collect2: error: ld returned 1 exit status
collect2: error: ld returned 1 exit status
make: *** [Makefile:78: viewadsb] Error 1
make: *** Waiting for unfinished jobs....
make: *** [Makefile:75: readsb] Error 1
```